### PR TITLE
Disable Parity warp

### DIFF
--- a/setup_templates/apollo/parity_config.toml
+++ b/setup_templates/apollo/parity_config.toml
@@ -4,6 +4,7 @@ chain = "/app/chain.json"
 
 [network]
 nat = "extip:<TYPE_YOUR_IP_HERE>"
+warp = false
 
 [rpc]
 apis = ["web3", "eth", "net", "parity"]

--- a/setup_templates/atlas/parity_config.toml
+++ b/setup_templates/atlas/parity_config.toml
@@ -2,6 +2,9 @@
 base_path = "/app/"
 chain = "/app/chain.json"
 
+[network]
+warp = false
+
 [rpc]
 apis = ["web3", "eth", "net"]
 interface = "all"

--- a/setup_templates/hermes/parity_config.toml
+++ b/setup_templates/hermes/parity_config.toml
@@ -2,6 +2,9 @@
 base_path = "/app/"
 chain = "/app/chain.json"
 
+[network]
+warp = false
+
 [rpc]
 apis = ["web3", "eth", "net"]
 interface = "all"


### PR DESCRIPTION
Disables the warp feature as this is not intended to work on private
chains and may cause us to sync from foreign chains which leads to
corrupt blocks.

Joshua Mir from the chat below is a core Parity dev.
```
joshua-mir @joshua-mir 14:58
no-warp... disables warp sync completely. you should be doing this with
a private chain/POA network because your peers likely aren't producing
snapshots for warp sync

if you warp on a private chain, chances are you might get blocks from...
other peoples chains with the same chainID
which wont be valid and will give you errors
```