### PR TITLE
Add update script

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -ex
+
+cd "$( dirname "${BASH_SOURCE[0]}" )"
+git pull origin master
+docker pull ambrosus/ambrosus-node:latest


### PR DESCRIPTION
Pulls the latest git repository and updates to the latest Docker images.

This could be embedded into the ambrosus-nop cli and you can use this PR
as a reference for what needs to be updated.