### PR TITLE
Update Party and ambrosus-node versions

### DIFF
--- a/setup_templates/apollo/docker-compose.yml
+++ b/setup_templates/apollo/docker-compose.yml
@@ -2,7 +2,7 @@
 version: '2.4'
 services:
   parity:
-    image: parity/parity:v2.0.8
+    image: parity/parity:v2.2.8
     entrypoint: /home/parity/bin/parity
     command: --config /app/parity_config.toml
     working_dir: /app

--- a/setup_templates/atlas/docker-compose.yml
+++ b/setup_templates/atlas/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./data/configdb:/data/configdb
 
   parity:
-    image: parity/parity:v2.0.8
+    image: parity/parity:v2.2.8
     entrypoint: /home/parity/bin/parity
     command: --config /app/parity_config.toml
     working_dir: /app
@@ -23,7 +23,7 @@ services:
       - ./parity_config.toml:/app/parity_config.toml
 
   worker: &atlas-props
-    image: ambrosus/ambrosus-node:latest
+    image: ambrosus/ambrosus-node:dc699ec
     command: sh -c 'yarn migrate && yarn start:atlas'
     restart: unless-stopped
     depends_on:

--- a/setup_templates/hermes/docker-compose.yml
+++ b/setup_templates/hermes/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - ./data/configdb:/data/configdb
 
   parity:
-    image: parity/parity:v2.0.8
+    image: parity/parity:v2.2.8
     entrypoint: /home/parity/bin/parity
     command: --config /app/parity_config.toml
     working_dir: /app
@@ -23,7 +23,7 @@ services:
       - ./parity_config.toml:/app/parity_config.toml
 
   worker: &hermes-props
-    image: ambrosus/ambrosus-node:latest
+    image: ambrosus/ambrosus-node:dc699ec
     command: sh -c 'yarn migrate && yarn start:hermes'
     restart: unless-stopped
     depends_on:

--- a/update.sh
+++ b/update.sh
@@ -4,4 +4,4 @@ set -ex
 cd "$( dirname "${BASH_SOURCE[0]}" )"
 git pull origin master
 yarn
-docker pull ambrosus/ambrosus-node:latest
+docker pull ambrosus/ambrosus-node:dc699ec


### PR DESCRIPTION
Latest is not actually latest any longer and we need to update by git
tag.